### PR TITLE
Add tags to ECS services

### DIFF
--- a/tf/modules/experiment/main.tf
+++ b/tf/modules/experiment/main.tf
@@ -54,8 +54,10 @@ resource "aws_ecs_task_definition" "target" {
   cpu    = 4 * 1024
   memory = 30 * 1024
 
-  tags     = {}
-  tags_all = {}
+  tags = {
+    "experiment" = var.name
+    "target"     = each.key
+  }
 
   ephemeral_storage {
     size_in_gib = 200


### PR DESCRIPTION
I had hoped this would allow to filter the Cloudwatch metrics, but it seems not