### PR TITLE
dealgood: allow target names to be specified; replace backend with target nomenclature

### DIFF
--- a/dealgood/cli.go
+++ b/dealgood/cli.go
@@ -24,7 +24,7 @@ func nogui(ctx context.Context, source RequestSource, exp *ExperimentJSON, print
 	if printHeader {
 		fmt.Printf("Time: %s\n", time.Now().Format(time.RFC1123Z))
 		fmt.Printf("Experiment: %s\n", exp.Name)
-		fmt.Printf("Duration: %ds\n", exp.Duration)
+		fmt.Printf("Duration: %s\n", durationDesc(exp.Duration))
 		fmt.Printf("Request rate: %d\n", exp.Rate)
 		fmt.Printf("Request concurrency: %d\n", exp.Concurrency)
 		fmt.Println("Targets:")
@@ -43,7 +43,7 @@ func nogui(ctx context.Context, source RequestSource, exp *ExperimentJSON, print
 		ExperimentName: exp.Name,
 		Rate:           exp.Rate,
 		Concurrency:    exp.Concurrency,
-		Duration:       time.Duration(exp.Duration) * time.Second,
+		Duration:       exp.Duration,
 		Timings:        timings,
 		PrintFailures:  printFailures,
 	}

--- a/dealgood/cli.go
+++ b/dealgood/cli.go
@@ -27,8 +27,8 @@ func nogui(ctx context.Context, source RequestSource, exp *ExperimentJSON, print
 		fmt.Printf("Duration: %ds\n", exp.Duration)
 		fmt.Printf("Request rate: %d\n", exp.Rate)
 		fmt.Printf("Request concurrency: %d\n", exp.Concurrency)
-		fmt.Println("Backends:")
-		for _, be := range exp.Backends {
+		fmt.Println("Targets:")
+		for _, be := range exp.Targets {
 			fmt.Printf("  %s (%s)\n", be.Name, be.BaseURL)
 		}
 		fmt.Println("")
@@ -48,8 +48,8 @@ func nogui(ctx context.Context, source RequestSource, exp *ExperimentJSON, print
 		PrintFailures:  printFailures,
 	}
 
-	for _, be := range exp.Backends {
-		l.Backends = append(l.Backends, &Backend{
+	for _, be := range exp.Targets {
+		l.Targets = append(l.Targets, &Target{
 			Name:    be.Name,
 			BaseURL: be.BaseURL,
 			Host:    be.Host,
@@ -74,7 +74,7 @@ func printCollectedTimings(ctx context.Context, coll *Collector, exp *Experiment
 	defer t.Stop()
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', tabwriter.AlignRight|tabwriter.Debug)
-	fmt.Fprintln(w, "time\tbackend\trequests\tconn errs\tdropped\t5xx errs\tTTFB P50\tTTFB P90\tTTFB P90")
+	fmt.Fprintln(w, "time\ttarget\trequests\tconn errs\tdropped\t5xx errs\tTTFB P50\tTTFB P90\tTTFB P90")
 	for {
 		select {
 		case <-ctx.Done():
@@ -83,7 +83,7 @@ func printCollectedTimings(ctx context.Context, coll *Collector, exp *Experiment
 
 			latest := coll.Latest()
 
-			for _, be := range exp.Backends {
+			for _, be := range exp.Targets {
 				st, ok := latest[be.Name]
 				if !ok {
 					continue
@@ -99,11 +99,11 @@ func printCollectedTimings(ctx context.Context, coll *Collector, exp *Experiment
 }
 
 func printSampleTimings(ctx context.Context, sample map[string]MetricSample, exp *ExperimentJSON) {
-	for i, be := range exp.Backends {
+	for i, be := range exp.Targets {
 		if i > 0 {
 			fmt.Println()
 		}
-		fmt.Printf("Backend:  %s\n", be.Name)
+		fmt.Printf("Target:  %s\n", be.Name)
 		fmt.Printf("Base URL: %s\n", be.BaseURL)
 		fmt.Printf("------------------------------\n")
 

--- a/dealgood/experiment.go
+++ b/dealgood/experiment.go
@@ -26,8 +26,8 @@ func validateExperiment(exp *ExperimentJSON) error {
 	if exp.Concurrency <= 0 {
 		return fmt.Errorf("concurrency must be greater than zero")
 	}
-	if exp.Duration <= 0 {
-		return fmt.Errorf("duration must be greater than zero")
+	if exp.Duration <= 0 && exp.Duration != -1 {
+		return fmt.Errorf("duration must be -1 or greater than zero ")
 	}
 
 	if len(exp.Targets) == 0 {

--- a/dealgood/experiment.go
+++ b/dealgood/experiment.go
@@ -6,17 +6,17 @@ import (
 )
 
 type ExperimentJSON struct {
-	Name        string         `json:"name"`
-	Rate        int            `json:"rate"`        // maximum number of requests per second per backend
-	Concurrency int            `json:"concurrency"` // number of concurrent requests per backend
-	Duration    int            `json:"duration"`    // suggested duration of the experiment in seconds
-	Backends    []*BackendJSON `json:"backends"`
+	Name        string        `json:"name"`
+	Rate        int           `json:"rate"`        // maximum number of requests per second per target
+	Concurrency int           `json:"concurrency"` // number of concurrent requests per target
+	Duration    int           `json:"duration"`    // suggested duration of the experiment in seconds
+	Targets     []*TargetJSON `json:"targets"`
 }
 
-type BackendJSON struct {
-	Name    string `json:"name"`           // short name of the backend to be used in reports
-	BaseURL string `json:"base_url"`       // base URL of the backend (without a path)
-	Host    string `json:"host,omitempty"` // An option hostname to be sent as a Host header in requests
+type TargetJSON struct {
+	Name    string `json:"name"`           // short name of the target to be used in reports
+	BaseURL string `json:"base_url"`       // base URL of the target (without a path)
+	Host    string `json:"host,omitempty"` // An optional hostname to be sent as a Host header in requests
 }
 
 func validateExperiment(exp *ExperimentJSON) error {
@@ -30,23 +30,23 @@ func validateExperiment(exp *ExperimentJSON) error {
 		return fmt.Errorf("duration must be greater than zero")
 	}
 
-	if len(exp.Backends) == 0 {
-		return fmt.Errorf("at least one backend must be specified")
+	if len(exp.Targets) == 0 {
+		return fmt.Errorf("at least one target must be specified")
 	}
 
 	seenNames := map[string]bool{}
-	for i, be := range exp.Backends {
+	for i, be := range exp.Targets {
 		if be.BaseURL == "" {
-			return fmt.Errorf("backend %d must have a base url", i+1)
+			return fmt.Errorf("target %d must have a base url", i+1)
 		}
 
 		u, err := url.Parse(be.BaseURL)
 		if err != nil {
-			return fmt.Errorf("backend %d must have a valid base url: %w", i+1, err)
+			return fmt.Errorf("target %d must have a valid base url: %w", i+1, err)
 		}
 
 		if u.Path != "" {
-			return fmt.Errorf("backend %d base url should not have a path", i+1)
+			return fmt.Errorf("target %d base url should not have a path", i+1)
 		}
 
 		if be.Name == "" {
@@ -54,14 +54,14 @@ func validateExperiment(exp *ExperimentJSON) error {
 		}
 
 		if seenNames[be.Name] {
-			return fmt.Errorf("duplicate backend name found: %s", be.Name)
+			return fmt.Errorf("duplicate target name found: %s", be.Name)
 		}
 		seenNames[be.Name] = true
 
 	}
 
 	if exp.Name == "" {
-		exp.Name = "unnamed"
+		return fmt.Errorf("experiment name must be specified")
 	}
 
 	return nil

--- a/dealgood/gui.go
+++ b/dealgood/gui.go
@@ -25,10 +25,10 @@ import (
 )
 
 type Gui struct {
-	source   RequestSource
-	backends []*Backend
-	cancel   func()
-	term     terminalapi.Terminal
+	source  RequestSource
+	targets []*Target
+	cancel  func()
+	term    terminalapi.Terminal
 
 	// widgets
 	chart         *linechart.LineChart
@@ -135,8 +135,8 @@ func NewGui(source RequestSource, exp *ExperimentJSON) (*Gui, error) {
 		statsFormatter:     &statsFormatters[0],
 	}
 
-	for _, be := range exp.Backends {
-		g.backends = append(g.backends, &Backend{
+	for _, be := range exp.Targets {
+		g.targets = append(g.targets, &Target{
 			Name:    be.Name,
 			BaseURL: be.BaseURL,
 			Host:    be.Host,
@@ -222,10 +222,10 @@ func NewGui(source RequestSource, exp *ExperimentJSON) (*Gui, error) {
 		return nil, fmt.Errorf("duration text: %w", err)
 	}
 
-	for _, be := range g.backends {
+	for _, be := range g.targets {
 		t, err := text.New(text.RollContent())
 		if err != nil {
-			return nil, fmt.Errorf("backend text: %w", err)
+			return nil, fmt.Errorf("target text: %w", err)
 		}
 		g.beStatsTexts[be.Name] = t
 
@@ -253,7 +253,7 @@ func (g *Gui) Show(ctx context.Context, redrawInterval time.Duration) error {
 
 	elems := []grid.Element{}
 
-	for i, be := range g.backends {
+	for i, be := range g.targets {
 		t, ok := g.beStatsTexts[be.Name]
 		if !ok {
 			continue
@@ -405,7 +405,7 @@ func (g *Gui) StartLoader(ctx context.Context) error {
 		l := &Loader{
 			Source:         g.source,
 			ExperimentName: g.experimentName,
-			Backends:       g.backends,
+			Targets:        g.targets,
 			Rate:           g.requestRate,
 			Concurrency:    g.requestConcurrency,
 			Duration:       g.duration,

--- a/dealgood/gui.go
+++ b/dealgood/gui.go
@@ -44,7 +44,7 @@ type Gui struct {
 
 	infoMu             sync.Mutex // guards changes to following
 	experimentName     string
-	duration           time.Duration
+	duration           int
 	durationsIdx       int
 	requestRate        int
 	requestRateIdx     int
@@ -58,13 +58,16 @@ type Gui struct {
 	latestSamples   map[string]MetricSample
 }
 
-var durations = []time.Duration{
-	1 * time.Minute,
-	5 * time.Minute,
-	15 * time.Minute,
-	60 * time.Minute,
-	180 * time.Minute,
-	720 * time.Minute,
+var durations = []int{
+	-1,
+	1 * 60,
+	5 * 60,
+	10 * 60,
+	15 * 60,
+	30 * 60,
+	60 * 60,
+	180 * 60,
+	720 * 60,
 }
 
 var requestRates = []int{
@@ -129,7 +132,7 @@ func NewGui(source RequestSource, exp *ExperimentJSON) (*Gui, error) {
 		beStatsTexts:       map[string]*text.Text{},
 		beColors:           map[string]cell.Color{},
 		experimentName:     exp.Name,
-		duration:           time.Duration(exp.Duration) * time.Second,
+		duration:           exp.Duration,
 		requestRate:        exp.Rate,
 		requestConcurrency: exp.Concurrency,
 		statsFormatter:     &statsFormatters[0],
@@ -393,7 +396,6 @@ func (g *Gui) OnKey(k *terminalapi.Keyboard) {
 
 func (g *Gui) StartLoader(ctx context.Context) error {
 	timings := make(chan *RequestTiming, 10000)
-	defer func() { close(timings) }()
 
 	coll, err := NewCollector(timings, 100*time.Millisecond)
 	if err != nil {
@@ -401,6 +403,7 @@ func (g *Gui) StartLoader(ctx context.Context) error {
 	}
 
 	go func() {
+		defer func() { close(timings) }()
 		g.infoMu.Lock()
 		l := &Loader{
 			Source:         g.source,
@@ -450,13 +453,15 @@ func (g *Gui) Update(ctx context.Context, coll *Collector) {
 			duration := g.duration
 			g.infoMu.Unlock()
 
-			// Update the progress indicator
-			passed := now.Sub(start)
-			percent := int(float64(passed) / float64(duration) * 100)
-			if percent > 100 {
-				continue
+			if duration != -1 {
+				// Update the progress indicator
+				passed := now.Sub(start)
+				percent := int(float64(passed) / float64(time.Duration(duration)*time.Second) * 100)
+				if percent > 100 {
+					continue
+				}
+				g.progressGauge.Percent(percent)
 			}
-			g.progressGauge.Percent(percent)
 
 			g.updateInfoText()
 
@@ -501,7 +506,8 @@ func (g *Gui) updateInfoText() {
 	g.infoText.Write("  Experiment: ", text.WriteCellOpts(cell.FgColor(cell.ColorBlue)))
 	g.infoText.Write(g.experimentName)
 	g.infoText.Write("  Duration: ", text.WriteCellOpts(cell.FgColor(cell.ColorBlue)))
-	g.infoText.Write(fmt.Sprintf("%v", g.duration))
+
+	g.infoText.Write(fmt.Sprintf("%v", durationDesc(g.duration)))
 	g.infoText.Write("  Rate: ", text.WriteCellOpts(cell.FgColor(cell.ColorBlue)))
 	g.infoText.Write(fmt.Sprintf("%d/s", g.requestRate))
 	g.infoText.Write("  Concurrency: ", text.WriteCellOpts(cell.FgColor(cell.ColorBlue)))
@@ -613,4 +619,19 @@ func formatStatLineFloat(t *text.Text, label string, value float64) string {
 
 func formatStatLineInt(t *text.Text, label string, value int) string {
 	return fmt.Sprintf("%-11s % 8d", label, value)
+}
+
+func durationDesc(d int) string {
+	if d == -1 {
+		return "forever"
+	}
+
+	s := (time.Duration(d) * time.Second).String()
+	if strings.HasSuffix(s, "m0s") {
+		s = s[:len(s)-2]
+	}
+	if strings.HasSuffix(s, "h0m") {
+		s = s[:len(s)-2]
+	}
+	return s
 }

--- a/dealgood/loader.go
+++ b/dealgood/loader.go
@@ -24,20 +24,17 @@ type Loader struct {
 	Timings        chan *RequestTiming // channel to send timings to
 	Rate           int                 // maximum number of requests per second per target
 	Concurrency    int                 // number of workers per target
-	Duration       time.Duration
+	Duration       int
 	PrintFailures  bool
-}
-
-type LoadOptions struct {
-	Rate        int // maximum number of requests per second per target
-	Concurrency int // number of workers per target
-	Duration    time.Duration
 }
 
 // Send sends requests to each target until the duration has passed or the context is canceled.
 func (l *Loader) Send(ctx context.Context) error {
-	ctx, cancel := context.WithTimeout(ctx, l.Duration)
-	defer cancel()
+	var cancel func()
+	if l.Duration > 0 {
+		ctx, cancel = context.WithTimeout(ctx, time.Duration(l.Duration)*time.Second)
+		defer cancel()
+	}
 
 	workers := make([]*Worker, 0, len(l.Targets)*l.Concurrency)
 	for _, be := range l.Targets {

--- a/dealgood/loader.go
+++ b/dealgood/loader.go
@@ -10,39 +10,39 @@ import (
 	"golang.org/x/net/http2"
 )
 
-type Backend struct {
-	Name     string // short name of the backend to be used in reports
-	BaseURL  string // base URL of the backend (without a path)
+type Target struct {
+	Name     string // short name of the target to be used in reports and metrics
+	BaseURL  string // base URL of the target (without a path)
 	Host     string
-	Requests chan *Request // channel used to receive requests to be issued to the backend
+	Requests chan *Request // channel used to receive requests to be issued to the target
 }
 
 type Loader struct {
 	Source         RequestSource // source of requests
 	ExperimentName string
-	Backends       []*Backend          // backends to send load to
+	Targets        []*Target           // targets to send load to
 	Timings        chan *RequestTiming // channel to send timings to
-	Rate           int                 // maximum number of requests per second per backend
-	Concurrency    int                 // number of workers per backend
+	Rate           int                 // maximum number of requests per second per target
+	Concurrency    int                 // number of workers per target
 	Duration       time.Duration
 	PrintFailures  bool
 }
 
 type LoadOptions struct {
-	Rate        int // maximum number of requests per second per backend
-	Concurrency int // number of workers per backend
+	Rate        int // maximum number of requests per second per target
+	Concurrency int // number of workers per target
 	Duration    time.Duration
 }
 
-// Send sends requests to each backend until the duration has passed or the context is canceled.
+// Send sends requests to each target until the duration has passed or the context is canceled.
 func (l *Loader) Send(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(ctx, l.Duration)
 	defer cancel()
 
-	workers := make([]*Worker, 0, len(l.Backends)*l.Concurrency)
-	for _, be := range l.Backends {
-		// One unbuffered request channel per backend, shared by all concurrent workers
-		// for that backend.
+	workers := make([]*Worker, 0, len(l.Targets)*l.Concurrency)
+	for _, be := range l.Targets {
+		// One unbuffered request channel per target, shared by all concurrent workers
+		// for that target.
 		if be.Requests == nil {
 			be.Requests = make(chan *Request)
 		}
@@ -59,7 +59,7 @@ func (l *Loader) Send(ctx context.Context) error {
 			http2.ConfigureTransport(tr)
 
 			workers = append(workers, &Worker{
-				Backend:        be,
+				Target:         be,
 				ExperimentName: l.ExperimentName,
 				Client: &http.Client{
 					Transport: tr,
@@ -93,20 +93,20 @@ func (l *Loader) Send(ctx context.Context) error {
 		}
 
 		req := l.Source.Request()
-		for _, be := range l.Backends {
+		for _, be := range l.Targets {
 			select {
 			case be.Requests <- &req:
 			default:
 				l.Timings <- &RequestTiming{
 					ExperimentName: l.ExperimentName,
-					BackendName:    be.Name,
+					TargetName:     be.Name,
 					Dropped:        true,
 				}
 			}
 		}
 		lastRequestDone = time.Now()
 	}
-	for _, be := range l.Backends {
+	for _, be := range l.Targets {
 		close(be.Requests)
 	}
 	wg.Wait()

--- a/dealgood/main.go
+++ b/dealgood/main.go
@@ -82,7 +82,7 @@ var app = &cli.App{
 		},
 		&cli.IntFlag{
 			Name:        "duration",
-			Usage:       "Duration of experiment in seconds(if not using an experiment file)",
+			Usage:       "Duration of experiment in seconds, -1 means forever (if not using an experiment file)",
 			Value:       60,
 			Destination: &flags.duration,
 			EnvVars:     []string{"DEALGOOD_DURATION"},

--- a/dealgood/main.go
+++ b/dealgood/main.go
@@ -30,7 +30,6 @@ var app = &cli.App{
 		&cli.StringFlag{
 			Name:        "experiment",
 			Usage:       "Name of the experiment",
-			Value:       "adhoc",
 			Destination: &flags.experimentName,
 			EnvVars:     []string{"DEALGOOD_EXPERIMENT"},
 		},
@@ -43,7 +42,7 @@ var app = &cli.App{
 		&cli.StringFlag{
 			Name:        "source",
 			Value:       "-",
-			Usage:       "Name of request source, use '-' to read JSON from stdin, 'random' to use some builtin random requests",
+			Usage:       "Name of request source, use '-' to read JSONL from stdin, 'random' to use some builtin random requests",
 			Destination: &flags.source,
 			EnvVars:     []string{"DEALGOOD_SOURCE"},
 		},
@@ -62,8 +61,8 @@ var app = &cli.App{
 		},
 		&cli.StringSliceFlag{
 			Name:        "targets",
-			Usage:       "Comma separated list of Base URLs of backends (if not using an experiment file)",
-			Value:       cli.NewStringSlice("http://localhost:8080"),
+			Usage:       "Comma separated list of Base URLs of targets, optionally each can be prefixed by a name, for example 'target::http://target.domain:8080' (if not using an experiment file)",
+			Value:       cli.NewStringSlice("local::http://localhost:8080"),
 			Destination: &flags.targets,
 			EnvVars:     []string{"DEALGOOD_TARGETS"},
 		},
@@ -187,10 +186,17 @@ func Run(cc *cli.Context) error {
 		exp.Concurrency = flags.concurrency
 		exp.Duration = flags.duration
 		for _, be := range flags.targets.Value() {
-			exp.Backends = append(exp.Backends, &BackendJSON{
+			bej := &TargetJSON{
 				BaseURL: be,
 				Host:    flags.host,
-			})
+			}
+			if name, base, found := strings.Cut(be, "::"); found {
+				bej.Name = name
+				bej.BaseURL = base
+			} else {
+				bej.BaseURL = be
+			}
+			exp.Targets = append(exp.Targets, bej)
 		}
 	}
 

--- a/dealgood/misc/example.json
+++ b/dealgood/misc/example.json
@@ -3,13 +3,13 @@
 	"duration": 120,
 	"rate": 300,
 	"concurrency": 10,
-	"backends": [
+	"targets": [
 		{
-			"name": "localhost1",
+			"name": "local1",
 			"base_url": "http://localhost:8080"
 		},
 		{
-			"name": "localhost2",
+			"name": "local2",
 			"base_url": "http://localhost:8080"
 		}
 	]


### PR DESCRIPTION
Allows target names to specified with command line flag or environment variable using a double colon separator between name and url:

`<name1>::<base_url1>,<name2>::<base_url2>`  

Also 

 - replaces all uses of Backend by Target in the codebase for consistency
 - makes experiment names required
 - allows the use of duration=-1 to mean run forever
