### PR TITLE
dealgood: resolve target names using SRV records if needed

### DIFF
--- a/dealgood/experiment.go
+++ b/dealgood/experiment.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"net/url"
+	"sync"
 )
 
 type ExperimentJSON struct {
@@ -19,50 +20,97 @@ type TargetJSON struct {
 	Host    string `json:"host,omitempty"` // An optional hostname to be sent as a Host header in requests
 }
 
-func validateExperiment(exp *ExperimentJSON) error {
-	if exp.Rate <= 0 {
-		return fmt.Errorf("rate must be greater than zero")
+type Experiment struct {
+	Name        string
+	Rate        int
+	Concurrency int
+	Duration    int
+	Targets     []*Target
+}
+
+type Target struct {
+	Name      string // short name of the target to be used in reports and metrics
+	BaseURL   string // base URL of the target (without a path)
+	HostName  string
+	URLScheme string
+	Requests  chan *Request // channel used to receive requests to be issued to the target
+
+	mu       sync.Mutex // guards accesses to hostPort which may change over time
+	hostPort string
+}
+
+func (t *Target) HostPort() string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.hostPort
+}
+
+func (t *Target) SetHostPort(hostport string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.hostPort = hostport
+}
+
+func newExperiment(expjson *ExperimentJSON) (*Experiment, error) {
+	if expjson.Name == "" {
+		return nil, fmt.Errorf("experiment name must be specified")
 	}
-	if exp.Concurrency <= 0 {
-		return fmt.Errorf("concurrency must be greater than zero")
+	if expjson.Rate <= 0 {
+		return nil, fmt.Errorf("rate must be greater than zero")
 	}
-	if exp.Duration <= 0 && exp.Duration != -1 {
-		return fmt.Errorf("duration must be -1 or greater than zero ")
+	if expjson.Concurrency <= 0 {
+		return nil, fmt.Errorf("concurrency must be greater than zero")
+	}
+	if expjson.Duration <= 0 && expjson.Duration != -1 {
+		return nil, fmt.Errorf("duration must be -1 or greater than zero ")
 	}
 
-	if len(exp.Targets) == 0 {
-		return fmt.Errorf("at least one target must be specified")
+	if len(expjson.Targets) == 0 {
+		return nil, fmt.Errorf("at least one target must be specified")
+	}
+
+	exp := &Experiment{
+		Name:        expjson.Name,
+		Rate:        expjson.Rate,
+		Concurrency: expjson.Concurrency,
+		Duration:    expjson.Duration,
 	}
 
 	seenNames := map[string]bool{}
-	for i, be := range exp.Targets {
-		if be.BaseURL == "" {
-			return fmt.Errorf("target %d must have a base url", i+1)
+	for i, tj := range expjson.Targets {
+		if tj.BaseURL == "" {
+			return nil, fmt.Errorf("target %d must have a base url", i+1)
 		}
 
-		u, err := url.Parse(be.BaseURL)
+		u, err := url.Parse(tj.BaseURL)
 		if err != nil {
-			return fmt.Errorf("target %d must have a valid base url: %w", i+1, err)
+			return nil, fmt.Errorf("target %d must have a valid base url: %w", i+1, err)
 		}
 
 		if u.Path != "" {
-			return fmt.Errorf("target %d base url should not have a path", i+1)
+			return nil, fmt.Errorf("target %d base url should not have a path", i+1)
 		}
 
-		if be.Name == "" {
-			be.Name = u.Hostname()
+		if tj.Name == "" {
+			tj.Name = u.Hostname()
 		}
 
-		if seenNames[be.Name] {
-			return fmt.Errorf("duplicate target name found: %s", be.Name)
+		if seenNames[tj.Name] {
+			return nil, fmt.Errorf("duplicate target name found: %s", tj.Name)
 		}
-		seenNames[be.Name] = true
+		seenNames[tj.Name] = true
+
+		t := &Target{
+			Name:      tj.Name,
+			BaseURL:   tj.BaseURL,
+			HostName:  tj.Host,
+			URLScheme: u.Scheme,
+			Requests:  make(chan *Request),
+			hostPort:  u.Host,
+		}
+		exp.Targets = append(exp.Targets, t)
 
 	}
 
-	if exp.Name == "" {
-		return fmt.Errorf("experiment name must be specified")
-	}
-
-	return nil
+	return exp, nil
 }

--- a/dealgood/gui.go
+++ b/dealgood/gui.go
@@ -126,7 +126,7 @@ var colors = []cell.Color{
 	cell.ColorFuchsia,
 }
 
-func NewGui(source RequestSource, exp *ExperimentJSON) (*Gui, error) {
+func NewGui(source RequestSource, exp *Experiment) (*Gui, error) {
 	g := &Gui{
 		source:             source,
 		beStatsTexts:       map[string]*text.Text{},
@@ -136,14 +136,7 @@ func NewGui(source RequestSource, exp *ExperimentJSON) (*Gui, error) {
 		requestRate:        exp.Rate,
 		requestConcurrency: exp.Concurrency,
 		statsFormatter:     &statsFormatters[0],
-	}
-
-	for _, be := range exp.Targets {
-		g.targets = append(g.targets, &Target{
-			Name:    be.Name,
-			BaseURL: be.BaseURL,
-			Host:    be.Host,
-		})
+		targets:            exp.Targets,
 	}
 
 	// Find the closest indices for the cycle-able values

--- a/dealgood/loader.go
+++ b/dealgood/loader.go
@@ -11,13 +11,6 @@ import (
 	"golang.org/x/net/http2"
 )
 
-type Target struct {
-	Name     string // short name of the target to be used in reports and metrics
-	BaseURL  string // base URL of the target (without a path)
-	Host     string
-	Requests chan *Request // channel used to receive requests to be issued to the target
-}
-
 type Loader struct {
 	Source         RequestSource // source of requests
 	ExperimentName string
@@ -39,16 +32,11 @@ func (l *Loader) Send(ctx context.Context) error {
 
 	workers := make([]*Worker, 0, len(l.Targets)*l.Concurrency)
 	for _, target := range l.Targets {
-		// One unbuffered request channel per target, shared by all concurrent workers
-		// for that target.
-		if target.Requests == nil {
-			target.Requests = make(chan *Request)
-		}
 		for j := 0; j < l.Concurrency; j++ {
 			tr := &http.Transport{
 				TLSClientConfig: &tls.Config{
 					InsecureSkipVerify: true,
-					ServerName:         target.Host,
+					ServerName:         target.HostName,
 				},
 				MaxIdleConnsPerHost: http.DefaultMaxIdleConnsPerHost,
 				DisableCompression:  true,


### PR DESCRIPTION
Fixes #46 

Currently only resolves the name on startup during the ready check. Will open a different issue to make it refresh periodically.