### PR TITLE
Fetch grafana-agent config from S3

### DIFF
--- a/tf/experiment-providerdelay.tf
+++ b/tf/experiment-providerdelay.tf
@@ -11,6 +11,8 @@ module "providerdelay" {
   log_group_name                                 = aws_cloudwatch_log_group.logs.name
   aws_service_discovery_private_dns_namespace_id = aws_service_discovery_private_dns_namespace.main.id
   ssm_exec_policy_arn                            = aws_iam_policy.ssm-exec.arn
+  grafana_agent_dealgood_config_url              = "http://${module.s3_bucket_public.s3_bucket_bucket_domain_name}/${module.grafana_agent_config["dealgood"].s3_object_id}"
+  grafana_agent_target_config_url                = "http://${module.s3_bucket_public.s3_bucket_bucket_domain_name}/${module.grafana_agent_config["target"].s3_object_id}"
 
   grafana_secrets = [
     { name = "GRAFANA_USER", valueFrom = "${data.aws_secretsmanager_secret.grafana-push-secret.arn}:username::" },

--- a/tf/experiment-releases.tf
+++ b/tf/experiment-releases.tf
@@ -11,6 +11,8 @@ module "releases" {
   log_group_name                                 = aws_cloudwatch_log_group.logs.name
   aws_service_discovery_private_dns_namespace_id = aws_service_discovery_private_dns_namespace.main.id
   ssm_exec_policy_arn                            = aws_iam_policy.ssm-exec.arn
+  grafana_agent_dealgood_config_url              = "http://${module.s3_bucket_public.s3_bucket_bucket_domain_name}/${module.grafana_agent_config["dealgood"].s3_object_id}"
+  grafana_agent_target_config_url                = "http://${module.s3_bucket_public.s3_bucket_bucket_domain_name}/${module.grafana_agent_config["target"].s3_object_id}"
 
   grafana_secrets = [
     { name = "GRAFANA_USER", valueFrom = "${data.aws_secretsmanager_secret.grafana-push-secret.arn}:username::" },

--- a/tf/experiment-reposize.tf
+++ b/tf/experiment-reposize.tf
@@ -11,6 +11,8 @@ module "reposize" {
   log_group_name                                 = aws_cloudwatch_log_group.logs.name
   aws_service_discovery_private_dns_namespace_id = aws_service_discovery_private_dns_namespace.main.id
   ssm_exec_policy_arn                            = aws_iam_policy.ssm-exec.arn
+  grafana_agent_dealgood_config_url              = "http://${module.s3_bucket_public.s3_bucket_bucket_domain_name}/${module.grafana_agent_config["dealgood"].s3_object_id}"
+  grafana_agent_target_config_url                = "http://${module.s3_bucket_public.s3_bucket_bucket_domain_name}/${module.grafana_agent_config["target"].s3_object_id}"
 
   grafana_secrets = [
     { name = "GRAFANA_USER", valueFrom = "${data.aws_secretsmanager_secret.grafana-push-secret.arn}:username::" },

--- a/tf/experiment-tweedles.tf
+++ b/tf/experiment-tweedles.tf
@@ -11,6 +11,8 @@ module "tweedles" {
   log_group_name                                 = aws_cloudwatch_log_group.logs.name
   aws_service_discovery_private_dns_namespace_id = aws_service_discovery_private_dns_namespace.main.id
   ssm_exec_policy_arn                            = aws_iam_policy.ssm-exec.arn
+  grafana_agent_dealgood_config_url              = "http://${module.s3_bucket_public.s3_bucket_bucket_domain_name}/${module.grafana_agent_config["dealgood"].s3_object_id}"
+  grafana_agent_target_config_url                = "http://${module.s3_bucket_public.s3_bucket_bucket_domain_name}/${module.grafana_agent_config["target"].s3_object_id}"
 
   grafana_secrets = [
     { name = "GRAFANA_USER", valueFrom = "${data.aws_secretsmanager_secret.grafana-push-secret.arn}:username::" },

--- a/tf/modules/experiment/dealgood.tf
+++ b/tf/modules/experiment/dealgood.tf
@@ -99,7 +99,13 @@ resource "aws_ecs_task_definition" "dealgood" {
     {
       name  = "grafana-agent"
       cpu   = 0
-      image = "147263665150.dkr.ecr.eu-west-1.amazonaws.com/grafana-agent:${var.dealgood_agent_tag}"
+      image = "grafana/agent:v0.26.1"
+      command = [
+        "-metrics.wal-directory=/data/grafana-agent",
+        "-config.expand-env",
+        "-enable-features=remote-configs",
+        "-config.file=${var.grafana_agent_dealgood_config_url}"
+      ]
       environment = [
         # we use these for setting labels on metrics
         { name = "THUNDERDOME_EXPERIMENT", value = var.name },

--- a/tf/modules/experiment/target.tf
+++ b/tf/modules/experiment/target.tf
@@ -110,7 +110,13 @@ resource "aws_ecs_task_definition" "target" {
     },
     {
       cpu   = 0
-      image = "147263665150.dkr.ecr.eu-west-1.amazonaws.com/grafana-agent:${var.target_agent_tag}"
+      image = "grafana/agent:v0.26.1"
+      command = [
+        "-metrics.wal-directory=/data/grafana-agent",
+        "-config.expand-env",
+        "-enable-features=remote-configs",
+        "-config.file=${var.grafana_agent_target_config_url}"
+      ]
       environment = [
         # we use these for setting labels on metrics
         { name = "THUNDERDOME_EXPERIMENT", value = var.name },

--- a/tf/modules/experiment/variables.tf
+++ b/tf/modules/experiment/variables.tf
@@ -32,14 +32,6 @@ variable "grafana_secrets" {
   default = []
 }
 
-variable "target_agent_tag" {
-  default = "target-75858d9"
-}
-
-variable "dealgood_agent_tag" {
-  default = "dealgood-d881af7"
-}
-
 variable "dealgood_tag" {
   default = "2022-09-08__1330"
 }

--- a/tf/modules/experiment/variables.tf
+++ b/tf/modules/experiment/variables.tf
@@ -54,5 +54,12 @@ variable "dealgood_secrets" {
 }
 
 variable "efs_file_system_id" {
-
 }
+
+variable "grafana_agent_dealgood_config_url" {
+}
+
+variable "grafana_agent_target_config_url" {
+}
+
+


### PR DESCRIPTION
This changes to use fetching config from S3, saves having to build an image for each as we were