### PR TITLE
Parse additional nginx log fields

### DIFF
--- a/cmd/dealgood/requests.go
+++ b/cmd/dealgood/requests.go
@@ -458,7 +458,7 @@ func (l *LokiRequestSource) Start() error {
 					Timestamp:  ll.Time,
 					RemoteAddr: ll.RemoteAddr,
 					UserAgent:  ll.UserAgent,
-					Referrer:   ll.Referrer,
+					Referer:    ll.Referer,
 				}
 			}
 		}

--- a/cmd/dealgood/requests.go
+++ b/cmd/dealgood/requests.go
@@ -452,10 +452,13 @@ func (l *LokiRequestSource) Start() error {
 				return
 			case ll := <-source.Chan():
 				l.ch <- request.Request{
-					Method:    ll.Method,
-					URI:       ll.URI,
-					Header:    ll.Headers,
-					Timestamp: ll.Time,
+					Method:     ll.Method,
+					URI:        ll.URI,
+					Header:     ll.Headers,
+					Timestamp:  ll.Time,
+					RemoteAddr: ll.RemoteAddr,
+					UserAgent:  ll.UserAgent,
+					Referrer:   ll.Referrer,
 				}
 			}
 		}

--- a/cmd/logtool/tail.go
+++ b/cmd/logtool/tail.go
@@ -217,7 +217,7 @@ func (p *Printer) Run(ctx context.Context) error {
 				Timestamp:  ll.Time,
 				RemoteAddr: ll.RemoteAddr,
 				UserAgent:  ll.UserAgent,
-				Referrer:   ll.Referrer,
+				Referer:    ll.Referer,
 			}
 			if p.filter != nil && !p.filter(&r) {
 				filtered++

--- a/cmd/logtool/tail.go
+++ b/cmd/logtool/tail.go
@@ -210,11 +210,14 @@ func (p *Printer) Run(ctx context.Context) error {
 			requests++
 
 			r := request.Request{
-				Method:    ll.Method,
-				URI:       ll.URI,
-				Header:    ll.Headers,
-				Status:    ll.Status,
-				Timestamp: ll.Time,
+				Method:     ll.Method,
+				URI:        ll.URI,
+				Header:     ll.Headers,
+				Status:     ll.Status,
+				Timestamp:  ll.Time,
+				RemoteAddr: ll.RemoteAddr,
+				UserAgent:  ll.UserAgent,
+				Referrer:   ll.Referrer,
 			}
 			if p.filter != nil && !p.filter(&r) {
 				filtered++

--- a/cmd/skyfish/publish.go
+++ b/cmd/skyfish/publish.go
@@ -127,7 +127,7 @@ func (p *Publisher) Run(ctx context.Context) error {
 				Timestamp:  ll.Time,
 				RemoteAddr: ll.RemoteAddr,
 				UserAgent:  ll.UserAgent,
-				Referrer:   ll.Referrer,
+				Referer:    ll.Referer,
 			}
 
 			data, err := json.Marshal(r)

--- a/cmd/skyfish/publish.go
+++ b/cmd/skyfish/publish.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -29,15 +28,6 @@ type Publisher struct {
 	messagesCounter     prometheus.Counter
 	requestsCounter     prometheus.Counter
 	connectedGauge      prometheus.Gauge
-}
-
-type Request struct {
-	Method    string            `json:"method"`
-	URI       string            `json:"uri"`
-	Body      []byte            `json:"body,omitempty"`
-	Header    map[string]string `json:"header"`
-	Status    int               `json:"status"` // status as reported by original server
-	Timestamp time.Time         `json:"ts"`     // time the request was created
 }
 
 func NewPublisher(awscfg *aws.Config, topicArn string, logch <-chan loki.LogLine) (*Publisher, error) {

--- a/cmd/skyfish/publish.go
+++ b/cmd/skyfish/publish.go
@@ -130,11 +130,14 @@ func (p *Publisher) Run(ctx context.Context) error {
 			}
 
 			r := request.Request{
-				Method:    ll.Method,
-				URI:       ll.URI,
-				Header:    ll.Headers,
-				Status:    ll.Status,
-				Timestamp: ll.Time,
+				Method:     ll.Method,
+				URI:        ll.URI,
+				Header:     ll.Headers,
+				Status:     ll.Status,
+				Timestamp:  ll.Time,
+				RemoteAddr: ll.RemoteAddr,
+				UserAgent:  ll.UserAgent,
+				Referrer:   ll.Referrer,
 			}
 
 			data, err := json.Marshal(r)

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -52,12 +52,15 @@ type LokiConfig struct {
 }
 
 type LogLine struct {
-	Server  string            `json:"server"`
-	Time    time.Time         `json:"time"`
-	Method  string            `json:"method"`
-	URI     string            `json:"uri"`
-	Status  int               `json:"status"`
-	Headers map[string]string `json:"headers"`
+	Server     string            `json:"server"`
+	Time       time.Time         `json:"time"`
+	Method     string            `json:"method"`
+	URI        string            `json:"uri"`
+	Status     int               `json:"status"`
+	Headers    map[string]string `json:"headers"`
+	RemoteAddr string            `json:"addr"`
+	UserAgent  string            `json:"agent"`
+	Referrer   string            `json:"referer"`
 }
 
 func NewLokiTailer(cfg *LokiConfig) (*LokiTailer, error) {

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -60,7 +60,7 @@ type LogLine struct {
 	Headers    map[string]string `json:"headers"`
 	RemoteAddr string            `json:"addr"`
 	UserAgent  string            `json:"agent"`
-	Referrer   string            `json:"referer"`
+	Referer    string            `json:"referer"`
 }
 
 func NewLokiTailer(cfg *LokiConfig) (*LokiTailer, error) {

--- a/pkg/request/request.go
+++ b/pkg/request/request.go
@@ -3,10 +3,13 @@ package request
 import "time"
 
 type Request struct {
-	Method    string            `json:"method"`
-	URI       string            `json:"uri"`
-	Body      []byte            `json:"body,omitempty"`
-	Header    map[string]string `json:"header"`
-	Status    int               `json:"status"` // status as reported by original server
-	Timestamp time.Time         `json:"ts"`     // time the request was created
+	Method     string            `json:"method"`
+	URI        string            `json:"uri"`
+	Body       []byte            `json:"body,omitempty"`
+	Header     map[string]string `json:"header"`
+	Status     int               `json:"status"` // status as reported by original server
+	Timestamp  time.Time         `json:"ts"`     // time the request was created
+	RemoteAddr string            `json:"remote_addr"`
+	UserAgent  string            `json:"agent"`
+	Referrer   string            `json:"referrer"`
 }

--- a/pkg/request/request.go
+++ b/pkg/request/request.go
@@ -11,5 +11,5 @@ type Request struct {
 	Timestamp  time.Time         `json:"ts"`     // time the request was created
 	RemoteAddr string            `json:"remote_addr"`
 	UserAgent  string            `json:"agent"`
-	Referrer   string            `json:"referrer"`
+	Referer    string            `json:"referer"`
 }


### PR DESCRIPTION
https://github.com/protocol/bifrost-infra/pull/2210 added additional log fields. This PR adds those fields to the internals of thunderdome.

If I remember/understand the thunderdome internals correctly, Dealgood may not need to parse/print these additional fields. If that's the case we could add `omitempty` to the new fields on the `LogLine` struct and just don't populate those fields?