### PR TITLE
Extend logs

### DIFF
--- a/cmd/dealgood/requests.go
+++ b/cmd/dealgood/requests.go
@@ -452,13 +452,16 @@ func (l *LokiRequestSource) Start() error {
 				return
 			case ll := <-source.Chan():
 				l.ch <- request.Request{
-					Method:     ll.Method,
-					URI:        ll.URI,
-					Header:     ll.Headers,
-					Timestamp:  ll.Time,
-					RemoteAddr: ll.RemoteAddr,
-					UserAgent:  ll.UserAgent,
-					Referer:    ll.Referer,
+					Method:       ll.Method,
+					URI:          ll.URI,
+					Header:       ll.Headers,
+					Status:       ll.Status,
+					Timestamp:    ll.Time,
+					RemoteAddr:   ll.RemoteAddr,
+					UserAgent:    ll.UserAgent,
+					Referer:      ll.Referer,
+					RespBodySize: ll.RespBodySize,
+					RespTime:     ll.RespTime,
 				}
 			}
 		}

--- a/cmd/logtool/tail.go
+++ b/cmd/logtool/tail.go
@@ -210,14 +210,16 @@ func (p *Printer) Run(ctx context.Context) error {
 			requests++
 
 			r := request.Request{
-				Method:     ll.Method,
-				URI:        ll.URI,
-				Header:     ll.Headers,
-				Status:     ll.Status,
-				Timestamp:  ll.Time,
-				RemoteAddr: ll.RemoteAddr,
-				UserAgent:  ll.UserAgent,
-				Referer:    ll.Referer,
+				Method:       ll.Method,
+				URI:          ll.URI,
+				Header:       ll.Headers,
+				Status:       ll.Status,
+				Timestamp:    ll.Time,
+				RemoteAddr:   ll.RemoteAddr,
+				UserAgent:    ll.UserAgent,
+				Referer:      ll.Referer,
+				RespBodySize: ll.RespBodySize,
+				RespTime:     ll.RespTime,
 			}
 			if p.filter != nil && !p.filter(&r) {
 				filtered++

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -52,15 +52,17 @@ type LokiConfig struct {
 }
 
 type LogLine struct {
-	Server     string            `json:"server"`
-	Time       time.Time         `json:"time"`
-	Method     string            `json:"method"`
-	URI        string            `json:"uri"`
-	Status     int               `json:"status"`
-	Headers    map[string]string `json:"headers"`
-	RemoteAddr string            `json:"addr"`
-	UserAgent  string            `json:"agent"`
-	Referer    string            `json:"referer"`
+	Server       string            `json:"server"`
+	Time         time.Time         `json:"time"`
+	Method       string            `json:"method"`
+	URI          string            `json:"uri"`
+	Status       int               `json:"status"`
+	Headers      map[string]string `json:"headers"`
+	RemoteAddr   string            `json:"addr"`
+	UserAgent    string            `json:"agent"`
+	Referer      string            `json:"referer"`
+	RespBodySize int               `json:"resp_body_size"`
+	RespTime     float32           `json:"resp_time"`
 }
 
 func NewLokiTailer(cfg *LokiConfig) (*LokiTailer, error) {

--- a/pkg/request/request.go
+++ b/pkg/request/request.go
@@ -3,13 +3,15 @@ package request
 import "time"
 
 type Request struct {
-	Method     string            `json:"method"`
-	URI        string            `json:"uri"`
-	Body       []byte            `json:"body,omitempty"`
-	Header     map[string]string `json:"header"`
-	Status     int               `json:"status"` // status as reported by original server
-	Timestamp  time.Time         `json:"ts"`     // time the request was created
-	RemoteAddr string            `json:"remote_addr"`
-	UserAgent  string            `json:"agent"`
-	Referer    string            `json:"referer"`
+	Method       string            `json:"method"`
+	URI          string            `json:"uri"`
+	Body         []byte            `json:"body,omitempty"`
+	Header       map[string]string `json:"header"`
+	Status       int               `json:"status"` // status as reported by original server
+	Timestamp    time.Time         `json:"ts"`     // time the request was created
+	RemoteAddr   string            `json:"remote_addr"`
+	UserAgent    string            `json:"agent"`
+	Referer      string            `json:"referer"`
+	RespBodySize int               `json:"resp_body_size"`
+	RespTime     float32           `json:"resp_time"`
 }


### PR DESCRIPTION
These fields are already logged by nginx. We're just piping them through.

@iand quick questions:

- the `referer` field is empty is `http_referer` the wrong field [here](https://github.com/protocol/bifrost-infra/blob/3f0538e3a406593b4d7c00eeedbdf9105cafd221/ansible/roles/nginx_conf_ipfs/templates/nginx.conf.j2#L55)?
- The `addr` field contains cloudflare IP's and not client IP's. Should we rather use `realip_remote_addr` instead of `remote_addr` [here](https://github.com/protocol/bifrost-infra/blob/3f0538e3a406593b4d7c00eeedbdf9105cafd221/ansible/roles/nginx_conf_ipfs/templates/nginx.conf.j2#L55)?
- Would the `upstream_cache_status` field be populated there? If so, I'd love to add that there as well. I can also ask in that `bifrost-infra` repo :+1: